### PR TITLE
Update run requirements for 2023.12 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,13 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python >=3.7
     - pip
   run:
-    - python >=3
+    - python >=3.7
+    - setuptools >=42.0.0
+    - importlib_metadata >=4.6  # [py<=310]
+    - packaging >=22.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,18 @@ source:
   sha256: bcbb2b25531c75acaf3672ebe7d032c6c62c1484a120aeeb4f565942fb6cf96c
 
 build:
+  noarch: python
   number: 1
-  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
   run:
-    - python
+    - python >=3.7
     - setuptools >=42.0.0
-    - importlib_metadata >=4.6  # [py<=310]
+    - importlib_metadata >=4.6
     - packaging >=22.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,15 @@ source:
 build:
   noarch: python
   number: 1
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
   run:
-    - python >=3.7
+    - python
     - setuptools >=42.0.0
     - importlib_metadata >=4.6  # [py<=310]
     - packaging >=22.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: bcbb2b25531c75acaf3672ebe7d032c6c62c1484a120aeeb4f565942fb6cf96c
 
 build:
-  noarch: python
   number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv


### PR DESCRIPTION
Fix https://github.com/conda-forge/pyinstaller-hooks-contrib-feedstock/issues/40

Also set Python version lower bound to 3.7 as specified by pyinstaller-hooks-contrib (https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/master/setup.cfg#L34) and remove `noarch: python`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
